### PR TITLE
feat: Add top-level directory and keep-files parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
       with:
         allure_results: ${{ inputs.allure-dir }}
         allure_history: allure-history
-        subfolder: ${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
+        subfolder: allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
         keep_reports: 10
 
     - name: Deploy report to Github Pages
@@ -62,7 +62,7 @@ runs:
           context: ${{ inputs.test-type }} test result
           state: ${{ job.status }}
           sha: ${{ github.event.pull_request.head.sha  || github.sha }}
-          target_url: ${{ steps.get_repo_url.outputs.url }}/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
+          target_url: ${{ steps.get_repo_url.outputs.url }}/allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
 
     - name: Set Job Summary
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   repository-name:
     description: 'Repository name'
     required: false
+  keep-files:
+    description: 'Do not overwrite exsiting files in pages'
+    default: false
+    required: false
 
 runs:
   using: "composite"
@@ -47,6 +51,7 @@ runs:
         github_token: ${{ inputs.github-key }}
         publish_branch: ${{ inputs.pages-branch }}
         publish_dir: allure-history
+        keep_files: ${{ inputs.keep-files }}
 
     - name: Post the link to the report
       if: always()

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,6 @@ runs:
         github_token: ${{ inputs.github-key }}
         publish_branch: ${{ inputs.pages-branch }}
         publish_dir: allure-history
-        destination_dir: allure
         keep_files: ${{ inputs.keep-files }}
 
     - name: Post the link to the report

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,7 @@ runs:
         github_token: ${{ inputs.github-key }}
         publish_branch: ${{ inputs.pages-branch }}
         publish_dir: allure-history
+        destination_dir: allure
         keep_files: ${{ inputs.keep-files }}
 
     - name: Post the link to the report
@@ -67,5 +68,5 @@ runs:
       if: always()
       shell: bash
       run: |
-        url="${{ steps.get_repo_url.outputs.url }}/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}"
+        url="${{ steps.get_repo_url.outputs.url }}/allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}"
         echo "#### ${{ env.GH_REPO }} [Report]($url)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Keep files allows multiple projects to deploy into gh-pages, like in JDBC when we deploy javadoc and allure.
Adding `allure` dir allows cleaner management of reports.