### PR TITLE
feat: support multiple report uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,25 +3,40 @@ GH Action to create Allure report on tests.
 
 This action requires github pages to be enabled.
 
+## v2
+- added support for upload of multiple reports within one job
+
 ## Inputs
 
-### github-key
+### github-token
 **Required:**  [Github token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
 
-### test-type
-Optional: Type of the test to distinguish when reporting. Integration or unit.
+### mapping-json
+**Required**: Mapping of source where allure test results were written and unique, URL friendly description
 
-Default: unit
+Example:
+```yaml
+mapping-json: |
+  {
+      "allure-results-unit": "unit_tests",
+      "allure-results-integration": "integration_tests"
+  }
+```
 
-### allure-dir
-Optional: Directory where allure report lives.
+### allure-version
+Optional: Version of Allure to be installed
 
-Default: allure-results
+Default: `2.38.1`
 
 ### pages-branch
 Optional: Branch where GitHub Pages is deployed.
 
 Default: gh-pages
+
+### report-path
+Optional: Path under which the report will be published.
+
+Default: `allure/<repo-name>_<sha>`
 
 ## Example usage
 
@@ -35,22 +50,15 @@ In the following example adding `--alluredir=allure-results` enables Allure repo
     run: |
     pytest tests/unit --alluredir=allure-results
 
-# Need to pull the pages branch in order to fetch the previous runs
-- name: Get Allure history
-    uses: actions/checkout@v2
-    if: always() # Needed in order to report failed tests
-    continue-on-error: true
-    with:
-        ref: gh-pages
-        path: gh-pages
-
 - name: Allure Report
-    uses: firebolt-db/action-allure-report@main
+    uses: firebolt-db/action-allure-report@v2
     if: always() # Needed in order to report failed tests
     with:
-        github-key: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         # The rest of the inputs are optional
-        test-type: Unit
-        allure-dir: allure-results
-        paged-branch: gh-pages
+        pages-branch: gh-pages
+        mapping-json: |
+            {
+                "allure-results": "unit_tests"
+            }
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,71 +1,152 @@
 name: Allure test report
-description: Create Github Pages hosted allure report
+description: Create Github Pages hosted allure reports
 
 inputs:
-  github-key:
+  github-token:
     description: 'Github token'
     required: true
-  test-type:
-    description: 'Integration or unit'
-    default: 'unit'
+  mapping-json:
+    description: 'Mapping of source where allure test results were written and unique, URL friendly description'
+    required: true
+    # Example:
+    # {
+    #   "allure-results": "core",
+    #   "allure-results-https": "core_https"
+    # }
+  allure-version:
+    description: 'Version of Allure to be installed'
     required: false
-  allure-dir:
-    description: 'Directory where allure report lives'
-    default: 'allure-results'
-    required: false
+    default: '2.38.1'
   pages-branch:
     description: 'Github Pages branch'
     default: 'gh-pages'
     required: false
-  repository-name:
-    description: 'Repository name'
-    required: false
-  keep-files:
-    description: 'Do not overwrite exsiting files in pages'
-    default: false
+  report-path:
+    description: 'Path under which the report will be published. Defaults to allure/<repo-name>_<sha>'
     required: false
 
 runs:
   using: "composite"
   steps:
-    - name: Get repo URL
-      shell: bash
-      id: get_repo_url
-      env:
-        GH_TOKEN: ${{ inputs.github-key }}
-      run: |
-        base_url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
-        echo "url=${base_url}" >> "$GITHUB_OUTPUT"
+      # Need to pull the pages branch in order to fetch the previous runs
+      - name: Get Allure history
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: always()
+        continue-on-error: true
+        with:
+          ref: ${{ inputs.pages-branch }}
+          path: ${{ inputs.pages-branch }}
+          persist-credentials: false
 
-    - name: Run Allure action
-      uses: simple-elf/allure-report-action@v1.13
-      with:
-        allure_results: ${{ inputs.allure-dir }}
-        allure_history: allure-history
-        subfolder: allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
-        keep_reports: 10
+      - name: Install Allure CLI
+        id: install-allure
+        if: always()
+        env:
+          ALLURE_VERSION: ${{ inputs.allure-version }}
+        shell: bash
+        run: |
+          npm install -g allure-commandline@${ALLURE_VERSION}
 
-    - name: Deploy report to Github Pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ inputs.github-key }}
-        publish_branch: ${{ inputs.pages-branch }}
-        publish_dir: allure-history
-        keep_files: ${{ inputs.keep-files }}
+      - name: Get repo gh-pages URL
+        id: get_repo_vars
+        env:
+          GH_TOKEN: ${{ inputs.github-token }}
+          GITHUB_SHA: ${{ github.sha }}
+          PROVIDED_REPORT_PATH: ${{ inputs.report-path }}
+        shell: bash
+        run: |
+          base_url=$(gh api "repos/$GITHUB_REPOSITORY/pages" --jq '.html_url')
+          repository_name=$(echo $GITHUB_REPOSITORY | cut -d '/' -f 2)
+          echo "repo_url=${base_url}" >> "$GITHUB_OUTPUT"
+          echo "repo_name=${repository_name}" >> "$GITHUB_OUTPUT"
 
-    - name: Post the link to the report
-      if: always()
-      uses: guibranco/github-status-action-v2@v1.1.13
-      with:
-          authToken: ${{ inputs.github-key }}
-          context: ${{ inputs.test-type }} test result
-          state: ${{ job.status }}
-          sha: ${{ github.event.pull_request.head.sha  || github.sha }}
-          target_url: ${{ steps.get_repo_url.outputs.url }}/allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}
+          if [ -z "${PROVIDED_REPORT_PATH}" ]; then
+            echo "report_path=allure/${repository_name}_${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "report_path=${PROVIDED_REPORT_PATH}" >> "$GITHUB_OUTPUT"
+          fi
 
-    - name: Set Job Summary
-      if: always()
-      shell: bash
-      run: |
-        url="${{ steps.get_repo_url.outputs.url }}/allure/${{ inputs.repository-name }}_${{ github.event.pull_request.head.sha  || github.sha }}_${{ inputs.test-type }}"
-        echo "#### ${{ env.GH_REPO }} [Report]($url)" >> $GITHUB_STEP_SUMMARY
+      - name: Generate All Reports Locally
+        id: generate-reports
+        if: always() && steps.install-allure.outcome == 'success'
+        env:
+          # Where to write allure reports
+          REPORT_DEST_BASE: "allure-final/${{ steps.get_repo_vars.outputs.report_path }}"
+          # From where allure reports are served
+          REPORT_URL_BASE: "${{ steps.get_repo_vars.outputs.repo_url }}${{ steps.get_repo_vars.outputs.report_path }}"
+          MAPPING_JSON: ${{ inputs.mapping-json }}
+        shell: bash
+        run: |
+          # Create a temp file to store URLs
+          echo "{}" > urls.json
+
+          echo "$MAPPING_JSON" | jq -r 'to_entries | .[] | "\(.key) \(.value)"' | while read -r src suffix; do
+            if [ -d "$src" ]; then
+              echo "Generating report: $src -> ${REPORT_DEST_BASE}_${suffix}"
+              allure generate "$src" -o "${REPORT_DEST_BASE}_${suffix}"
+
+              # Build URL and update the temp JSON file
+              FINAL_URL="${REPORT_URL_BASE}_${suffix}"
+              jq --arg k "$suffix" --arg v "$FINAL_URL" '. + {($k): $v}' urls.json > urls.tmp && mv urls.tmp urls.json
+            else
+              echo "⚠️ Skipping: Directory '$src' not found."
+            fi
+          done
+          echo "urls=$(cat urls.json | jq -c .)" >> $GITHUB_OUTPUT
+
+      - name: Deploy all reports to GitHub Pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        id: deploy-reports
+        if: always() && steps.generate-reports.outcome == 'success' && steps.generate-reports.outputs.urls != '{}'
+        with:
+          github_token: ${{ inputs.github-token }}
+          publish_branch: ${{ inputs.pages-branch }}
+          publish_dir: ./allure-final
+          keep_files: true
+
+      - name: Update PR Status
+        if: always()
+        env:
+          GH_TOKEN: ${{ inputs.github-token }}
+          URLS_JSON: ${{ steps.generate-reports.outputs.urls || '{}'}}
+          SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          JOB_STATUS: ${{ job.status }}
+          API_URL: "https://api.github.com/repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }}"
+        shell: bash
+        run: |
+          # Map job status to GitHub Status API state
+          case "${JOB_STATUS}" in
+            success) STATE="success" ;;
+            failure) STATE="failure" ;;
+            cancelled) STATE="error" ;;
+            *) STATE="error" ;;
+          esac
+
+          # Parse the JSON output and loop through each name/url pair
+          echo "$URLS_JSON" | jq -r 'to_entries | .[] | "\(.key) \(.value)"' | while read -r name url; do
+            echo "Setting status for $name..."
+
+            curl -fsSL \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$API_URL" \
+              -d "{
+                \"state\": \"$STATE\",
+                \"target_url\": \"$url\",
+                \"description\": \"Firebolt Core Test Result ($name)\",
+                \"context\": \"integration-tests-core ($name)\"
+              }"
+          done
+
+      - name: Set Job Summary
+        if: always() && steps.deploy-reports.outcome == 'success'
+        env:
+          URLS_JSON: ${{ steps.generate-reports.outputs.urls || '{}'}}
+        shell: bash
+        run: |
+          echo "### Test Reports" >> $GITHUB_STEP_SUMMARY
+          echo "$URLS_JSON" | jq -r 'to_entries | .[] | "\(.key) \(.value)"' | while read -r name url; do
+            echo "* [Report: $name]($url)" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
**Description**
Implement a new version of this action that supports upload of multiple allure reports within a single job. Single allure report upload is still supported.

- Some parameter have been renamed/replaced.
- Removed obsolete dependency onto `simple-elf/allure-report-action`
- Moved master branch to `release/v1` branch. Users that pin `@v1` can continue to use the previous version.

Tested in: https://github.com/firebolt-db/firebolt-python-sdk/pull/497