### PR TITLE
ci: add option to provide ref

### DIFF
--- a/.github/workflows/major-release.yml
+++ b/.github/workflows/major-release.yml
@@ -2,6 +2,11 @@ name: Move Major Release Tag
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'vX.Y.Z'
+        type: string
+        required: true
   release:
     types: [created]
 
@@ -15,8 +20,16 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Get major version num and update tag
+      shell: bash
+      env:
+        PROVIDED_TAG: ${{ inputs.tag }}
       run: |
-        VERSION=${GITHUB_REF#refs/tags/}
+        if [ ! -z ${PROVIDED_TAG} ]; then
+          VERSION=${PROVIDED_TAG}
+        else
+          VERSION=${GITHUB_REF#refs/tags/}
+        fi
+        echo "Using version ${VERSION}"
         MAJOR=${VERSION%%.*}
         git config --global user.name 'Release Bot'
         git config --global user.email 'release-bot@firebolt.io'


### PR DESCRIPTION
**Description**
When using workflow_dispatch, we need to provide the tag. On the release trigger the ref (tag) is provided by GH.

Successful run here: https://github.com/firebolt-db/action-allure-report/actions/runs/23640471643