### PR TITLE
ci: persist-credentials to push tag

### DIFF
--- a/.github/workflows/major-release.yml
+++ b/.github/workflows/major-release.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
-        persist-credentials: false
+        persist-credentials: true
 
     - name: Get major version num and update tag
       shell: bash


### PR DESCRIPTION
**Description**
We need to keep the credentials for the `git push` in the next step to succeed